### PR TITLE
Fix ws auth when subaccounts are used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftx-api",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Node.js connector for FTX's REST APIs and WebSockets",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -160,7 +160,7 @@ export class WebsocketClient extends EventEmitter {
   }
 
   private requestTryAuthenticate(wsKey: string) {
-    const { key, secret } = this.options;
+    const { key, secret, subAccountName } = this.options;
     if (!key || !secret) {
       this.logger.debug(`Connection "${wsKey}" will remain unauthenticated due to missing key/secret`);
       return;
@@ -171,6 +171,7 @@ export class WebsocketClient extends EventEmitter {
       key,
       signWsAuthenticate(timestamp, secret),
       timestamp,
+      subAccountName,
     );
     this.tryWsSend(wsKey, JSON.stringify(authMsg));
   }


### PR DESCRIPTION
Fixes #6. Subaccount param wasn't being passed in ws auth msg.