### PR TITLE
Get trigger order history is calling the wrong endpoint

### DIFF
--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -295,7 +295,6 @@ export class RestClient {
     side?: OrderSide;
     type?: ConditionalOrderType;
     orderType?: OrderType;
-    limit?: number;
   }): GenericAPIResponse {
     return this.requestWrapper.get(`conditional_orders/history`, params);
   }


### PR DESCRIPTION
#40 

- Fix wrong url
- Remove non valid `limit` param