### PR TITLE
Dust endpoints

### DIFF
--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -426,6 +426,24 @@ export class RestClient {
   }
 
   /**
+   * 
+   * Dust
+   *
+   **/
+
+  requestDust(toCoin: string): GenericAPIResponse {
+    return this.requestWrapper.post(`dust/quotes`, { toCoin });
+  }
+
+  getDustStatus(quoteId: string): GenericAPIResponse {
+    return this.requestWrapper.get(`dust/quotes/${quoteId}`);
+  }
+
+  acceptDust(quoteId: string): GenericAPIResponse {
+    return this.requestWrapper.post(`dust/quotes/${quoteId}/accept`);
+  }
+
+  /**
    *
    * Spot Margin Endpoints
    * https://docs.ftx.com/#spot-margin

--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -46,6 +46,18 @@ export class RestClient {
     return this.requestWrapper.get('notifications/get_announcements?language=' + language);
   }
 
+  requestDust(toCoin: string): GenericAPIResponse {
+    return this.requestWrapper.post(`dust/quotes`, { toCoin });
+  }
+
+  getDustStatus(quoteId: string): GenericAPIResponse {
+    return this.requestWrapper.get(`dust/quotes/${quoteId}`);
+  }
+
+  acceptDust(quoteId: string): GenericAPIResponse {
+    return this.requestWrapper.post(`dust/quotes/${quoteId}/accept`);
+  }
+
   /**
    *
    * Subaccount Endpoints
@@ -423,24 +435,6 @@ export class RestClient {
 
   acceptQuote(quoteId: string): GenericAPIResponse {
     return this.requestWrapper.post(`otc/quotes/${quoteId}/accept`);
-  }
-
-  /**
-   * 
-   * Dust
-   *
-   **/
-
-  requestDust(toCoin: string): GenericAPIResponse {
-    return this.requestWrapper.post(`dust/quotes`, { toCoin });
-  }
-
-  getDustStatus(quoteId: string): GenericAPIResponse {
-    return this.requestWrapper.get(`dust/quotes/${quoteId}`);
-  }
-
-  acceptDust(quoteId: string): GenericAPIResponse {
-    return this.requestWrapper.post(`dust/quotes/${quoteId}/accept`);
   }
 
   /**


### PR DESCRIPTION
closes #49 

This PR includes 3 functions for the "dust" endpoints, which is used for converting small amounts of different coins to a base currency all at once. These endpoints are undocumented but they're currently used by the FTX web app in production.

on the client side it behaves the same as the OTC "convert" endpoints: the requestDust() function returns a `quoteId` that can be accepted with acceptDust(quoteId)