### PR TITLE
🐛 use relative path instead of path alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftx-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node.js/typescript connector for FTX's REST APIs and WebSockets",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -1,4 +1,4 @@
-import { WsEventTrades } from "src";
+import { WsEventTrades } from "../";
 
 export function isWsTradesEvent(msg: WsEventTrades): msg is WsEventTrades {
   return msg && msg.channel === 'trades' && msg.type === 'update' && Array.isArray(msg.data);


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## Summary
Fix a path issue on `typeGuards.ts`.

Using TypeScript to compile a project using ftx-api@1.1.0 will generate the following error:
```
> tsc

node_modules/ftx-api/lib/util/typeGuards.d.ts:1:31 - error TS2307: Cannot find module 'src' or its corresponding type declarations.

1 import { WsEventTrades } from "src";
                                ~~~~~

Found 1 error.
```

This PR addresses that issue, allowing a successful compilation.

Local tests were performed by compiling the package and installing it (using `npm i ../ftx-api/ftx-api-1.1.1.tgz`) and checking if the the compilation was successful.


##  Checks
- [ ] Updated related documentation
- [ ] Updated/added related tests
- [X] I have tested my changes locally
