### PR TITLE
v1.1.4: increase default pong timeout to match other connectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ftx-api",
-  "version": "1.0.19",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftx-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Node.js/typescript connector for FTX's REST APIs and WebSockets",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -47,7 +47,7 @@ export class WebsocketClient extends EventEmitter {
     this.wsStore = new WsStore(this.logger);
 
     this.options = {
-      pongTimeout: 1000,
+      pongTimeout: 7500,
       pingInterval: 10000,
       reconnectTimeout: 500,
       ...options


### PR DESCRIPTION
The default pong timeout for ws heartbeats was quite aggressive (only allowing 1 second before assuming a connection drop). This may give a lot of false alarms during api latency. Increased this to 7500, matching my other connectors too.