### PR TITLE
fixed a bug when serialisedParams are empty

### DIFF
--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -191,7 +191,12 @@ export default class RequestUtil {
       };
     }
 
-    const signature_payload = `${timestamp}${method}/api/${endpoint}${serialisedParams}`;
+    let signature_payload;
+    if (serialisedParams==='?') {
+      signature_payload = `${timestamp}${method}/api/${endpoint}`;
+    } else {
+      signature_payload = `${timestamp}${method}/api/${endpoint}${serialisedParams}`;
+    }
 
     return {
       timestamp,


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## Summary
<!--
Thanks for creating this pull request.

Please make sure that the pull request is limited to one type (enhancement, bug, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

<!-- Add a brief description of the pr -->
There was a bug when trying to access the fills endpoints with empty params. 
The signature generation would be based on "https://...fills?" instead of "https://...fills". 
The extra ? generated an invalid signature.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

##  Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] Updated related documentation
- [ ] Updated/added related tests
- [x] I have tested my changes locally
