### PR TITLE
FTX API requires a method for the withdrawal to go through

### DIFF
--- a/src/types/rest.ts
+++ b/src/types/rest.ts
@@ -72,7 +72,7 @@ export interface WithdrawalReq {
   tag?: string;
   password?: string;
   code?: string;
-  method: string;
+  method?: string;
 }
 
 export interface NewSavedAddressReq {


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
When attempting to make a withdrawal to the Avalanche chain i experienced an issue. After discussing the issue with the FTX support team I was provided the following guidance:

<img width="517" alt="image" src="https://user-images.githubusercontent.com/709085/176332981-58d901fb-63d0-457e-98e1-c750550d3ff6.png">

This PR simply adds the method as a param to pass through to the FTX API so that withdrawals can function correctly.
